### PR TITLE
Fixed CommonJS exports

### DIFF
--- a/dist/pegasus-commonjs.js
+++ b/dist/pegasus-commonjs.js
@@ -45,4 +45,4 @@ function pegasus(a, xhr) {
   return xhr;
 }
 
-module.export = pegasus;
+module.exports = pegasus;

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "pegasus",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "description": "Load data while still loading other scripts, works with jQuery, Backbone, Angular...",
   "main": "dist/pegasus-commonjs.js",
   "scripts": {

--- a/src/commonjs.js
+++ b/src/commonjs.js
@@ -1,3 +1,3 @@
 @@include('pegasus.js')
 
-module.export = pegasus;
+module.exports = pegasus;


### PR DESCRIPTION
the commonjs file was broken in `module.export`. It was missing the "s": `module.exports`