### PR TITLE
Fixed problem when exception is raised in callback

### DIFF
--- a/src/pegasus.js
+++ b/src/pegasus.js
@@ -11,29 +11,30 @@ function pegasus(a, xhr) {
 
   // onSuccess handler
   // onError   handler
-  // cb        placeholder to avoid using var, should not be used
-  xhr.onreadystatechange = xhr.then = function(onSuccess, onError, cb) {
+  // cb, js    placeholders to avoid using var, should not be used
+  xhr.onreadystatechange = xhr.then = function(onSuccess, onError, cb, js) {
 
     // Test if onSuccess is a function
-    if (onSuccess && onSuccess.call) a = [,onSuccess, onError];
+    if (onSuccess && onSuccess.call) { a = [null, onSuccess, onError]; }
 
     // Test if request is complete
-    if (xhr.readyState == 4) {
+    if (xhr.readyState === 4) {
 
       // index will be:
       // 0 if undefined
       // 1 if status is between 200 and 399
       // 2 if status is over
-      cb = a[0|xhr.status / 200];
+      cb = a[0 | xhr.status / 200];
 
       // Safari doesn't support xhr.responseType = 'json'
       // so the response is parsed
       if (cb) {
         try {
-          cb(JSON.parse(xhr.responseText), xhr);
+          js = JSON.parse(xhr.responseText);
         } catch (e) {
-          cb(null, xhr);
+          js = null;
         }
+        cb(js, xhr);
       }
     }
   };


### PR DESCRIPTION
When the callback that is called in this code:

        try {
          cb(JSON.parse(xhr.responseText), xhr);
        } catch (e) {
          cb(null, xhr);
        }

throws an exception, it will cause that callback to be called again, this time with null for data. This is not good :)

I fixed this by performing the JSON conversion in a separate step.

I also made small adjustments to please ESLint.

I didn't minify the code.