### PR TITLE
Add Alternative CDN

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,13 @@ To save a network call, it's recommended to simply paste the following code [peg
 
 ### CDN
 
-https://unpkg.com/@typicode/pegasus/dist/pegasus.min.js
+
+
+```html
+<script src="https://cdn.jsdelivr.net/npm/@typicode/pegasus@0/dist/pegasus.min.js"></script>
+<!-- or -->
+<script src="https://unpkg.com/@typicode/pegasus/dist/pegasus.min.js"></script>
+```
 
 ### npm
 


### PR DESCRIPTION
I added a [jsDelivr CDN link](https://www.jsdelivr.com/package/npm/@typicode/pegasus) to your readme as an alternative to unpkg. jsDelivr is the fastest opensource CDN available and built specifically for production usage. It can serve any project from npm with zero config just like unpkg, but offers a larger network and better reliability.